### PR TITLE
Initial port to @thorpej's 6809 Playground computer.

### DIFF
--- a/alf/Makefile
+++ b/alf/Makefile
@@ -10,7 +10,8 @@ G6CC_BAUD = 115200
 
 #
 
-BIN_PATH = ../../bin
+#BIN_PATH = ../../bin
+BIN_PATH = /opt/pkg/bin
 SRC_PATH = ./src
 
 ASM6809 = $(BIN_PATH)/lwasm
@@ -20,6 +21,9 @@ ASM6809_FLAGS = --format=ihex
 
 alf: $(SRC_PATH)/*.asm $(SRC_PATH)/*.lib
 	$(ASM6809) $(ASM6809_FLAGS) $(SRC_PATH)/alf.asm --output=alf.hex --list=alf.lst
+
+alf-pg09: $(SRC_PATH)/*.asm $(SRC_PATH)/*.lib
+	$(ASM6809) --define=PG09 $(ASM6809_FLAGS) $(SRC_PATH)/alf.asm --format=raw --output=alf-pg09.raw --list=alf-pg09.lst
 
 debug: $(SRC_PATH)/*.asm $(SRC_PATH)/*.lib
 	$(ASM6809) --define=DEBUG $(ASM6809_FLAGS) $(SRC_PATH)/alf.asm --output=debug.hex --list=debug.lst

--- a/alf/Makefile
+++ b/alf/Makefile
@@ -15,15 +15,17 @@ BIN_PATH = /opt/pkg/bin
 SRC_PATH = ./src
 
 ASM6809 = $(BIN_PATH)/lwasm
-ASM6809_FLAGS = --format=ihex
 
 #
 
+all: alf alf-pg09
+
 alf: $(SRC_PATH)/*.asm $(SRC_PATH)/*.lib
-	$(ASM6809) $(ASM6809_FLAGS) $(SRC_PATH)/alf.asm --output=alf.hex --list=alf.lst
+	$(ASM6809) --format=ihex $(SRC_PATH)/alf.asm --output=alf.hex --list=alf.lst
 
 alf-pg09: $(SRC_PATH)/*.asm $(SRC_PATH)/*.lib
-	$(ASM6809) --define=PG09 $(ASM6809_FLAGS) $(SRC_PATH)/alf.asm --format=raw --output=alf-pg09.raw --list=alf-pg09.lst
+	$(ASM6809) --define=PG09 --define=PG09_BROM --format=raw $(SRC_PATH)/alf.asm --output=alf-pg09.brom --list=alf-pg09-brom.lst
+	$(ASM6809) --define=PG09 --define=PG09_HBRAM --format=srec $(SRC_PATH)/alf.asm --output=alf-pg09.s19 --list=alf-pg09-hbram.lst
 
 debug: $(SRC_PATH)/*.asm $(SRC_PATH)/*.lib
 	$(ASM6809) --define=DEBUG $(ASM6809_FLAGS) $(SRC_PATH)/alf.asm --output=debug.hex --list=debug.lst

--- a/alf/src/alf.asm
+++ b/alf/src/alf.asm
@@ -85,4 +85,4 @@ alf_dp$		equ		*						;initial dictionary pointer
 alf_end$	equ		*						;end of all code
 alf_defs$	equ		_head					;last defined word
 
-			end
+			end	ALF_KER_ORG

--- a/alf/src/alf.asm
+++ b/alf/src/alf.asm
@@ -50,7 +50,11 @@
 			pragma	6809,dollarnotlocal,cescapes
 
 			pragma	nolist
+			IFDEF PG09
+			include "pg09.lib"
+			ELSE
 			include	"g6cc.lib"
+			ENDIF
 			include "ascii.lib"
 			pragma	list
 

--- a/alf/src/con.asm
+++ b/alf/src/con.asm
@@ -173,6 +173,52 @@ prs_		ldb		,x+								;X = start
 ;@@@ RAW (HARDWARE) CONSOLE I/O
 ;@@@
 
+	IFDEF PG09
+
+; >>> Console initialization (for @thorpej's 6809 Playground)
+; The Playground kernel has already done this for us; no need
+; to do anything else.
+con$init
+	rts
+
+; >>> Poll for raw console input (for @thorpej's 6809 Playground)
+; We can use the "cons_pollc" System Subroutine for this.  The Zero
+; flag is used in the same way by the Playground kernel, but it
+; leaves the value in A undefined if not character is available.
+; If Zero is clear, then the character is returned in A.
+; RETURNS: NE,B = input char else EQ,B = 0 if none avail
+con$rdcq
+	pshs	A		; Save A
+	jsr	[SysSubr_cons_pollc] ; Call kernel's cons_pollc
+	bne	@charavail	; Z clear -> character in A
+	clrb			; sets Z
+	puls	A,PC		; Restore and return
+@charavail
+	tfr	A,B		; return character in B
+	puls	A,PC		; Restore and return
+
+; >>> Pause console input (set RTS=1)
+; There is no mechanism for this on the Playground.  The console UART
+; has an auto-/RTS circuit, so at least overflows won't occur.
+con$pause
+	rts
+
+; >>> Resume console input (set RTS=0)
+; See above.
+con$resume
+	rts
+
+; >>> @thorpej's 6809 Playground: Display character
+; We can use the "cons_putc" System Subroutine for this.
+; PASSED:  B = character to display
+con$prc
+	pshs	A		; Save A
+	tfr	B,A		; Kernel wants character to display in A
+	jsr	[SysSubr_cons_putc] ; Call kernel's cons_putc
+	puls	A,PC		; Restore and return
+
+	ELSE
+
 ; >>> Console initialization (for Grant's 6 Chip Computer h/w)
 ; 115200 baud, 8N1, RTS=0, RX INT enabled (in case wired for h/w handshake)
 con$init	lda		#ACIA_CTL_CDS_MRESET
@@ -206,3 +252,5 @@ con$prc		lda		#ACIA_STAT_TDRE_MASK
 			beq		@wait
 			stb		G6CC_ACIA_DATA
 			rts
+
+	ENDIF

--- a/alf/src/equ.asm
+++ b/alf/src/equ.asm
@@ -15,7 +15,11 @@ ALF_RO_SIZE		equ		$2000
 ALF_RW_ORG		equ		$0000						;read/write area
 ALF_RW_SIZE		equ		$4FFF
 	ELSE
+	IFDEF PG09_HBRAM
+ALF_RO_ORG		equ		$A000						;read/only area
+	ELSE
 ALF_RO_ORG		equ		$C000						;read/only area
+	ENDIF ; PG09_HBRAM
 ALF_RO_SIZE		equ		$2000
 ALF_RW_ORG		equ		$0000						;read/write area
 ALF_RW_SIZE		equ		$7F00

--- a/alf/src/pg09.lib
+++ b/alf/src/pg09.lib
@@ -15,6 +15,6 @@ G6CC_ROM_SIZE			equ		$2000
 
 	; Console I/O routines provided by the operating system
 	; kernel.
-SysSubr_cons_getc		equ		$E008
-SysSubr_cons_pollc		equ		$E00A
-SysSubr_cons_putc		equ		$E00C
+SysSubr_cons_getc		equ		$E00A
+SysSubr_cons_pollc		equ		$E00C
+SysSubr_cons_putc		equ		$E00E

--- a/alf/src/pg09.lib
+++ b/alf/src/pg09.lib
@@ -1,0 +1,20 @@
+; pg09.lib - definitions for @thorpej's 6809 Playground computer
+
+	; Processor
+	; (Hopefully we don't need the CPU speed constants for Alf -- the
+	; 6809 Playground has jumper-selectable CPU speeds... but we can
+	; read it from a register, if necessary.)
+
+	; Memory Map
+
+G6CC_RAM_ORG			equ		$0000	; Low banked RAM
+G6CC_RAM_SIZE			equ		$8000
+
+G6CC_ROM_ORG			equ		$C000	; Banked ROM
+G6CC_ROM_SIZE			equ		$2000
+
+	; Console I/O routines provided by the operating system
+	; kernel.
+SysSubr_cons_getc		equ		$E008
+SysSubr_cons_pollc		equ		$E00A
+SysSubr_cons_putc		equ		$E00C

--- a/syl/Makefile
+++ b/syl/Makefile
@@ -10,7 +10,8 @@ G6CC_BAUD = 115200
 
 #
 
-BIN_PATH = ../../bin
+#BIN_PATH = ../../bin
+BIN_PATH = /opt/pkg/bin
 SRC_PATH = ./src
 
 ASM6809 = $(BIN_PATH)/lwasm
@@ -20,6 +21,9 @@ ASM6809_FLAGS = --format=ihex
 
 syl: $(SRC_PATH)/*.asm $(SRC_PATH)/*.lib
 	$(ASM6809) $(ASM6809_FLAGS) $(SRC_PATH)/syl.asm --output=syl.hex --list=syl.lst
+
+syl-pg09: $(SRC_PATH)/*.asm $(SRC_PATH)/*.lib
+	$(ASM6809) --define=PG09 $(ASM6809_FLAGS) $(SRC_PATH)/syl.asm --format=raw --output=syl-pg09.raw --list=syl-pg09.lst
 
 debug: $(SRC_PATH)/*.asm $(SRC_PATH)/*.lib
 	$(ASM6809) --define=DEBUG $(ASM6809_FLAGS) $(SRC_PATH)/syl.asm --output=debug.hex --list=debug.lst

--- a/syl/Makefile
+++ b/syl/Makefile
@@ -15,15 +15,17 @@ BIN_PATH = /opt/pkg/bin
 SRC_PATH = ./src
 
 ASM6809 = $(BIN_PATH)/lwasm
-ASM6809_FLAGS = --format=ihex
 
 #
 
+all: syl syl-pg09
+
 syl: $(SRC_PATH)/*.asm $(SRC_PATH)/*.lib
-	$(ASM6809) $(ASM6809_FLAGS) $(SRC_PATH)/syl.asm --output=syl.hex --list=syl.lst
+	$(ASM6809) --format=ihex $(SRC_PATH)/syl.asm --output=syl.hex --list=syl.lst
 
 syl-pg09: $(SRC_PATH)/*.asm $(SRC_PATH)/*.lib
-	$(ASM6809) --define=PG09 $(ASM6809_FLAGS) $(SRC_PATH)/syl.asm --format=raw --output=syl-pg09.raw --list=syl-pg09.lst
+	$(ASM6809) --define=PG09 --define=PG09_BROM --format=raw $(SRC_PATH)/syl.asm --output=syl-pg09.brom --list=syl-pg09-brom.lst
+	$(ASM6809) --define=PG09 --define=PG09_HBRAM --format=srec $(SRC_PATH)/syl.asm --output=syl-pg09.s19 --list=syl-pg09-hbram.lst
 
 debug: $(SRC_PATH)/*.asm $(SRC_PATH)/*.lib
 	$(ASM6809) --define=DEBUG $(ASM6809_FLAGS) $(SRC_PATH)/syl.asm --output=debug.hex --list=debug.lst

--- a/syl/src/pg09.lib
+++ b/syl/src/pg09.lib
@@ -15,6 +15,6 @@ G6CC_ROM_SIZE			equ		$2000
 
 	; Console I/O routines provided by the operating system
 	; kernel.
-SysSubr_cons_getc		equ		$E008
-SysSubr_cons_pollc		equ		$E00A
-SysSubr_cons_putc		equ		$E00C
+SysSubr_cons_getc		equ		$E00A
+SysSubr_cons_pollc		equ		$E00C
+SysSubr_cons_putc		equ		$E00E

--- a/syl/src/pg09.lib
+++ b/syl/src/pg09.lib
@@ -1,0 +1,20 @@
+; pg09.lib - definitions for @thorpej's 6809 Playground computer
+
+	; Processor
+	; (Hopefully we don't need the CPU speed constants for Alf -- the
+	; 6809 Playground has jumper-selectable CPU speeds... but we can
+	; read it from a register, if necessary.)
+
+	; Memory Map
+
+G6CC_RAM_ORG			equ		$0000	; Low banked RAM
+G6CC_RAM_SIZE			equ		$8000
+
+G6CC_ROM_ORG			equ		$C000	; Banked ROM
+G6CC_ROM_SIZE			equ		$2000
+
+	; Console I/O routines provided by the operating system
+	; kernel.
+SysSubr_cons_getc		equ		$E008
+SysSubr_cons_pollc		equ		$E00A
+SysSubr_cons_putc		equ		$E00C

--- a/syl/src/syl.asm
+++ b/syl/src/syl.asm
@@ -73,7 +73,11 @@ CODE_END			equ		$7F00							;end address (below Demon vars)
 CODE_SIZE			equ		CODE_END-CODE_ORG
 	ELSE
 CONS_POOL_END		equ		$7F00							;end in EPROM build
+	IFDEF PG09
+CODE_ORG			equ		$C000							;Interpreter Code area (in Banked ROM)
+	ELSE
 CODE_ORG			equ		$D000							;Interpreter Code arera (in EPROM)
+	ENDIF
 CODE_SIZE			equ		$1000
 CODE_END			equ		CODE_ORG+CODE_SIZE
 	ENDIF

--- a/syl/src/syl.asm
+++ b/syl/src/syl.asm
@@ -74,7 +74,11 @@ CODE_SIZE			equ		CODE_END-CODE_ORG
 	ELSE
 CONS_POOL_END		equ		$7F00							;end in EPROM build
 	IFDEF PG09
+	IFDEF PG09_BROM
 CODE_ORG			equ		$C000							;Interpreter Code area (in Banked ROM)
+	ELSE
+CODE_ORG			equ		$A000							;Interpreter Code area (in High Banked RAM)
+	ENDIF ; PG09_BROM
 	ELSE
 CODE_ORG			equ		$D000							;Interpreter Code arera (in EPROM)
 	ENDIF
@@ -390,4 +394,4 @@ syl_end	equ *
 	ERROR "GC Mark Pool init wants pool size a multiple of 4 for speed"
 	ENDIF
 
-		end
+		end	CODE_ORG

--- a/syl/src/syl.asm
+++ b/syl/src/syl.asm
@@ -37,7 +37,11 @@
 			pragma	6809,dollarnotlocal,cescapes
 
 			pragma	nolist
+			IFDEF PG09
+			include "pg09.lib"
+			ELSE
 			include	"g6cc.lib"
+			ENDIF
 			include "ascii.lib"
 			pragma	list
 


### PR DESCRIPTION
Uses Playground OS console I/O routines in lieu of direct hardware access.  Each program's code lives in its own banked ROM bank, for now.  Once Playground OS has file system access routines, the programs will be changed to run from high banked RAM.
